### PR TITLE
fix: issue #14 edit mode bug (focus management and widget persistence)

### DIFF
--- a/py_mind_memo/view.py
+++ b/py_mind_memo/view.py
@@ -258,9 +258,9 @@ class MindMapView:
         clicked_node = self.find_node_at(cx, cy)
         
         if clicked_node:
-            # 既に編集中なら一旦キャンセル（前の変更はFocusOutで保存されているはず）
+            # 既に編集中なら一旦保存・終了
             if self.editor.is_editing():
-                self.editor.cancel_edit()
+                self.editor.finish_edit()
             
             self.selected_node = clicked_node
             # self.render() は on_edit_node -> start_edit 内で必要な場合に行われるか、


### PR DESCRIPTION
## 概要
Issue #14 で報告された、トピックス編集モード中に他のトピックをダブルクリックするとキー操作が不能になるバグを修正しました。

## 原因
1. **キャンバスのフォーカス管理**: 編集モード中、キャンバスをクリックしてもフォーカスが移らなかったため、エディタウィジェットの `FocusOut` イベントが発生せず、編集が正常に終了していませんでした。
2. **ウィジェットの強制削除**: ダブルクリック時の再描画（`render()`）により、編集中のウィジェットがキャンバスから一方的に削除されていました。これにより `NodeEditor` の内部状態と画面上の表示が不整合になっていました。

## 修正内容
- `view.py`: `_on_canvas_click` で常にキャンバスにフォーカスを当てるようにし、既存エディタの `FocusOut` を確実に発生させるようにしました。
- `view.py`: `_on_canvas_double_click` で `render()` の呼び出しを削除し、新しい編集を開始する前に既存の編集を明示的にキャンセル（クリーンアップ）するようにしました。
- `editor.py`: `is_editing()` メソッドでウィジェットの実体が存在するかを確認するようにし、不整合を防ぐようにしました。

## 検証結果
- ノード編集 -> 他のノードをダブルクリック の一連の操作で、前の編集が保存され、新しいノードの編集が正常に開始されることを確認しました。
- 既存のユニットテスト（10件）がすべてパスすることを確認しました。

Closes #14