### PR TITLE
fix: is_modified フラグの設定漏れを修正 (#36)

### DIFF
--- a/py_mind_memo/editor.py
+++ b/py_mind_memo/editor.py
@@ -181,6 +181,7 @@ class NodeEditor:
             # モデルの更新（この時点では一時的、finish_editで確定）
             node.image_data = self.image_handler.base64_from_photo(photo)
             node.image_path = file_path
+            self.model.is_modified = True
         except ValueError as e:
             messagebox.showerror("Error", str(e))
         except tk.TclError as e:

--- a/py_mind_memo/view.py
+++ b/py_mind_memo/view.py
@@ -234,6 +234,7 @@ class MindMapView:
                         node = self.model.find_node_by_id(t)
                         if node:
                             node.collapsed = not node.collapsed
+                            self.model.is_modified = True
                             self.selected_node = node
                             self.render()
                             return True

--- a/tests/test_issue36_is_modified.py
+++ b/tests/test_issue36_is_modified.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import tkinter as tk
+from py_mind_memo.models import MindMapModel, Node
+from py_mind_memo.editor import NodeEditor
+from py_mind_memo.view import MindMapView
+
+class TestIssue36IsModified(unittest.TestCase):
+    def setUp(self):
+        self.root = tk.Tk()
+        self.canvas = tk.Canvas(self.root)
+        self.model = MindMapModel("Root")
+        self.node = self.model.root
+        
+    def tearDown(self):
+        self.root.destroy()
+
+    @patch('py_mind_memo.editor.ImageHandler.pick_and_load_image')
+    @patch('py_mind_memo.editor.ImageHandler.process_image')
+    @patch('py_mind_memo.editor.ImageHandler.base64_from_photo')
+    def test_insert_image_sets_is_modified(self, mock_b64, mock_process, mock_pick):
+        # Setup mocks
+        mock_pick.return_value = "dummy.png"
+        mock_process.return_value = MagicMock(spec=tk.PhotoImage)
+        mock_b64.return_value = "dummy_base64"
+        
+        # Initialize NodeEditor
+        editor = NodeEditor(self.canvas, self.root, MagicMock(), lambda: None, self.model)
+        
+        # Start editing (needed to set editing_entry)
+        editor.start_edit(self.node)
+        # Mock image_create to avoid TclError with Mock PhotoImage
+        editor.editing_entry.image_create = MagicMock()
+        
+        # Initial state
+        self.model.is_modified = False
+        
+        # Execute insert_image
+        editor.insert_image(self.node)
+        
+        # Verification
+        self.assertTrue(self.model.is_modified, "is_modified should be True after inserting image")
+
+    def test_collapse_click_sets_is_modified(self):
+        # Initialize MindMapView (with mocks to avoid full GUI setup issues)
+        with patch('py_mind_memo.view.GraphicsEngine'), \
+             patch('py_mind_memo.view.LayoutEngine'), \
+             patch('py_mind_memo.view.NodeEditor'), \
+             patch('py_mind_memo.view.DragDropHandler'), \
+             patch('py_mind_memo.view.KeyboardNavigator'), \
+             patch('py_mind_memo.view.PersistenceHandler'), \
+             patch('py_mind_memo.view.MindMapView._create_menu'), \
+             patch('py_mind_memo.view.MindMapView.render'):
+            
+            view = MindMapView(self.root)
+            view.model = self.model
+            
+            # Create a node and tag it as collapse_icon
+            node = self.model.add_node(self.model.root, "Child")
+            node_id = node.id
+            
+            # Mock canvas.find_overlapping and canvas.gettags
+            view.canvas.find_overlapping = MagicMock(return_value=[123])
+            view.canvas.gettags = MagicMock(return_value=("collapse_icon", node_id))
+            
+            # Initial state
+            self.model.is_modified = False
+            
+            # Execute _handle_node_collapse_click
+            # Use real coordinates but find_overlapping is mocked
+            view._handle_node_collapse_click(10, 10)
+            
+            # Verification
+            self.assertTrue(self.model.is_modified, "is_modified should be True after toggling collapse")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 概要 (Summary)
画像挿入時およびノードの折りたたみ・展開操作時に、データモデルの変更フラグ（is_modified）が正しくセットされない不具合を修正しました。これにより、自動保存や終了時の保存確認が意図通りに動作するようになります。

## 変更点 (Changes)
- py_mind_memo/editor.py: insert_image メソッドにおいて、画像データ更新直後に self.model.is_modified = True を設定するように変更。
- py_mind_memo/view.py: _handle_node_collapse_click メソッドにおいて、ノードの開閉状態反転直後に self.model.is_modified = True を設定するように変更。
- 	ests/test_issue36_is_modified.py: 上記の修正が正しく機能することを検証するユニットテストを追加。

## レビューのポイント (Focus Areas)
- フラグ設定のタイミングが適切か。
- 追加されたテストが各ケースを網羅しているか。

## 関連Issue (References)
- Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 画像を挿入した際に、変更が正しく追跡されるよう改善しました
  * ノードを折りたたんだ際に、変更が正しく追跡されるよう改善しました

* **テスト**
  * 画像挿入と折りたたみ操作での状態管理を検証するテストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->